### PR TITLE
Changed the crate name to glfw_sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glfw-sys"
-version = "3.1.0"
+version = "3.1.2"
 authors = ["Camilla Berglund <elmindreda@elmindreda.org>"]
 
 build = "build.rs"
@@ -13,5 +13,5 @@ readme = "README.md"
 license = "Zlib/Libpng"
 
 [lib]
-name = "glfw-sys"
+name = "glfw_sys"
 path = "lib.rs"


### PR DESCRIPTION
Otherwise getting this:

> failed to parse manifest at `.../glfw/Cargo.toml`
