### PR TITLE
Make the build script output metadata rather than flags.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,5 +37,6 @@ fn main() {
              &Path::new(env!("OUT_DIR")).join("libglfw3.a"))
              .ok().expect("Failed to move file");
 
-    println!("cargo:rustc-flags=-L {} -l glfw3:static", env!("OUT_DIR"));
+    println!("cargo:rustc-link-lib=static=glfw3");
+    println!("cargo:rustc-link-search=native={}", env!("OUT_DIR"));
 }


### PR DESCRIPTION
This means cargo passes exactly the right flags to rustc, including
search paths and so on, whereas previously it would trigger errors due
to rustc and/or the linker not picking things up correctly.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glfw/20)

<!-- Reviewable:end -->
